### PR TITLE
Potential fix for code scanning alert no. 8: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/routes/opportunities.py
+++ b/routes/opportunities.py
@@ -54,7 +54,7 @@ async def get_opportunities(
         user_id = user.id if user else None
         client_ip = request.client.host if request.client else "unknown"
         session_data = f"{user_id}:{client_ip}:{request.headers.get('user-agent', '')}"
-        session_id = hashlib.md5(session_data.encode()).hexdigest()[:12]
+        session_id = hashlib.sha256(session_data.encode()).hexdigest()[:12]
         
         # Track dashboard activity
         dashboard_activity.track_dashboard_access(user_id=user_id, session_id=session_id)


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/fair-edge/security/code-scanning/8](https://github.com/dock108/fair-edge/security/code-scanning/8)

To fix the issue, replace the use of the MD5 hashing algorithm with a stronger and more secure alternative. For general-purpose cryptographic hashing, SHA-256 (from the `hashlib` library) is a suitable choice. It is resistant to pre-image and collision attacks and is widely supported.

The fix involves:
1. Replacing `hashlib.md5` with `hashlib.sha256` on line 57.
2. Updating the code to handle the longer hash output of SHA-256. Since the original code truncates the MD5 hash to 12 characters, we will apply the same truncation to the SHA-256 hash for consistency.

No additional imports are required, as `hashlib` already provides SHA-256.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
